### PR TITLE
Fix linkam SDK initialisation

### DIFF
--- a/microscope/stages/linkam.py
+++ b/microscope/stages/linkam.py
@@ -991,7 +991,7 @@ class _LinkamBase(microscope.abc.FloatingDeviceMixin, microscope.abc.Device):
         ]
         for p in lpaths:
             lskpath = os.path.join(p, "Linkam.lsk")
-            if _lib.linkamInitialiseSDK(sdk_log, lskpath.encode(), True):
+            if _lib.linkamInitialiseSDK(sdk_log, lskpath.encode(), True) == 1:
                 break
         else:
             raise microscope.LibraryLoadError(


### PR DESCRIPTION
linkamInitialiseSDK returns large positive int if failed, passing the check and breaking. This makes the check specific to ensure it succeeded (returns 1).