### PR TITLE
prior: fix AttributeError for bad connections

### DIFF
--- a/microscope/controllers/prior.py
+++ b/microscope/controllers/prior.py
@@ -211,15 +211,17 @@ class ProScanIII(microscope.abc.Controller):
     def __init__(
         self, port: str, baudrate: int = 9600, timeout: float = 0.5, **kwargs
     ) -> None:
-        super().__init__(**kwargs)
-        self._conn = _ProScanIIIConnection(port, baudrate, timeout)
         self._devices: Mapping[str, microscope.abc.Device] = {}
+
+        self._conn = _ProScanIIIConnection(port, baudrate, timeout)
 
         # Can have up to three filter wheels, numbered 1 to 3.
         for number in range(1, 4):
             if self._conn.has_filterwheel(number):
                 key = "filter %d" % number
                 self._devices[key] = _ProScanIIIFilterWheel(self._conn, number)
+
+        super().__init__(**kwargs)
 
     @property
     def devices(self) -> Mapping[str, microscope.abc.Device]:


### PR DESCRIPTION
When constructing a `ProScanIII` object on a port that does not connect to a Prior controller, the `_devices` member is not defined.

This causes the `__del__` operation of the object to fail, because it will end up in the base class' `__del__`, which requires the `devices` property, which is overridden to use the `self._devices` member.

Conceptually, the base class requires the implementation to be a valid object.  One may also argue that the object is not allowed to be constructed at all if not connected to a proper device; that would be an alternative fix.

I tested (Before/After) with this snippet:

```python
from microscope.controllers import prior

good = prior.ProScanIII("COM5")
try:
    bad = prior.ProScanIII("COM3")
except RuntimeError as e:
    assert "Not a ProScanIII device" in str(e)
```